### PR TITLE
Update reentrancy.py

### DIFF
--- a/ilf/fuzzers/checkers/reentrancy.py
+++ b/ilf/fuzzers/checkers/reentrancy.py
@@ -15,7 +15,7 @@ class Reentrancy(Checker):
         pc1, pc2 = -1, -1
         
         for log in logger.logs:
-            if log.op == CALL and int(log.stack[-3], 16) > 0:  # CALL: [gas  addr  value  argsOffset  argsLength  retOffset  retLength]
+            if log.op == CALL and int(log.stack[-3], 16) > 0 and int(log.stack[-1], 16) > 0 :  # CALL: [gas  addr  value  argsOffset  argsLength  retOffset  retLength]
                 has_transfer = True
                 pc1 = log.pc
             if log.op == SSTORE :


### PR DESCRIPTION
During test, I have found some false positives with _send_ and _transfer_ method, which are safe from re-entrancy vulnerability. So I add the constraint, the gas value of CALL op should be positive integer, to eliminate these warnings.

Please feel free to merge this pr. This modification is safe for the whole project.
